### PR TITLE
chore(ci): clean up Dependabot config — reviewer routing via CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "automated"
     groups:
-      patch-security:
+      patches:
         update-types:
           - "patch"
 
@@ -17,6 +14,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    labels:
-      - "dependencies"
-      - "automated"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "automated"
     groups:
-      patch-security:
+      patches:
         update-types:
           - "patch"
 
@@ -17,9 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    labels:
-      - "dependencies"
-      - "automated"
+    open-pull-requests-limit: 5
     groups:
       # github/codeql-action's sub-actions (init/autobuild/analyze/upload-sarif)
       # are one repo pinned by one SHA and REQUIRE lockstep versions: init writes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,3 +29,8 @@ GOVERNANCE.md @iracic82 @ivanglabbeek
 MAINTAINERS.md @iracic82 @ivanglabbeek
 SECURITY.md @iracic82 @ivanglabbeek
 TRADEMARKS.md @iracic82 @ivanglabbeek
+
+# Python dependency manifests — both maintainers approve so Dependabot pip
+# bumps surface to the same reviewer pair as github-actions bumps in .github/
+pyproject.toml @iracic82 @ivanglabbeek
+uv.lock @iracic82 @ivanglabbeek


### PR DESCRIPTION
## Summary

Four config-only cleanups to `.github/dependabot.yml` plus a CODEOWNERS extension. The CODEOWNERS edit is the substantive change — see the **Governance note** below.

All four surfaced during a review of the Dependabot setup that landed in #119/#120/#121. No workflow logic changes, no auto-merge eligibility changes.

| # | Change | Why |
|---|---|---|
| 1 | Rename group `patch-security` → `patches` | The rule was `update-types: [patch]` — it groups **all** patches, not security-only, so the original name was misleading. Renaming preserves current behavior. **If the original intent was security-only grouping, the right fix is `applies-to: security-updates` instead — see review request to @iracic82 in the PR comments.** |
| 2 | Add `open-pull-requests-limit: 5` to `github-actions` ecosystem | This is the Dependabot schema default, so behavior is unchanged. The line makes the cap explicit in config rather than relying on a default that could shift, and matches the existing `pip` block for consistency. |
| 3 | Route Dependabot reviewer assignment via CODEOWNERS instead of `reviewers:` | GitHub removed the `reviewers` field from Dependabot v2 (announced [2025-04-29](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/), removed [2025-08-08](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/)) — CODEOWNERS is the canonical replacement. The IDE schema linter rejects the field with `Property reviewers is not allowed`. This PR extends CODEOWNERS so pip bumps surface to both maintainers instead of only the catchall. See governance note below. |
| 4 | Drop `dependencies` / `automated` labels from `dependabot.yml` | They weren't wired to triage, branch protection, or the auto-merge eligibility check (which keys off `github.actor`). Re-add if/when a downstream policy reads them. |

## Governance note — CODEOWNERS scope

The CODEOWNERS additions in this PR are not Dependabot-specific. They route **every** edit (human or bot) to these paths to both maintainers:

```
pyproject.toml @iracic82 @ivanglabbeek
uv.lock        @iracic82 @ivanglabbeek
```

Practical effect:

- New dependency adds and pip version bumps in `pyproject.toml` now require both maintainers' approval.
- `uv.lock` regenerations require both maintainers' approval.
- The `version = "..."` bump in `pyproject.toml` during release prep also requires both — confirm this fits the current release flow before merging.

This is a deliberate bus-factor / supply-chain choice ahead of LF intake: dependency-manifest edits are the highest-leverage attack surface a single maintainer can land. If the project does not want this tightening, drop the two new CODEOWNERS lines and accept that Dependabot pip PRs route only to `@iracic82` via the catchall.

## Out of scope

- Pip patch auto-merge currently relies on green CI without hash-pinned requirements (supply-chain typosquat / hijack surface noted in #121's commit message). Tracking separately for the `uv sync --frozen` migration.
- `dependency-review-action` for transitive-CVE gating.
- Adding `@NWillAU900` to CODEOWNERS — listed as DNS Standards Lead in `MAINTAINERS.md` but has no routing rules; either fold him into spec-adjacent paths (`docs/rfc/`, `src/dns_aid/core/`) or document the role boundary. Separate PR.

## Test plan

- [x] CI passes (DCO, ruff, mypy, pytest, scorecard, codeql)
- [ ] After merge: next Dependabot github-actions PR auto-requests review from `@iracic82` + `@ivanglabbeek` via `.github/` CODEOWNERS rule
- [ ] After merge: next Dependabot pip PR auto-requests review from `@iracic82` + `@ivanglabbeek` via the new `pyproject.toml` / `uv.lock` rule
- [ ] Manual check pre-merge: confirm release flow's `pyproject.toml` version bump path is compatible with two-maintainer CODEOWNERS routing
