### PR TITLE
feat(core): surface operator-defined cap-document fields as AgentRecord.cap_metadata

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -584,6 +584,7 @@ agent = AgentRecord(
 | `ttl` | `int` | No | 3600 | DNS TTL (60-86400) |
 | `cap_uri` | `str` | No | `None` | URI to capability document (DNS-AID) |
 | `cap_sha256` | `str` | No | `None` | SHA-256 digest of capability descriptor |
+| `cap_metadata` | `dict[str, Any]` | No | `{}` | Operator-defined fields of the fetched capability document (every key beyond the known schema). Opaque, unverified passthrough — judge integrity via `cap_sha256_verified`, same as `capabilities` |
 | `bap` | `list[str]` | No | `[]` | Supported protocols with versions |
 | `policy_uri` | `str` | No | `None` | URI to agent policy document |
 | `realm` | `str` | No | `None` | Multi-tenant scope identifier |

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -636,6 +636,12 @@ async def _query_single_agent(
             capability_source: CapabilitySource = "none"
             agent_card = None
             cap_sha256_applied = False
+            # Operator-defined cap-document fields (issue #174): opaque,
+            # unverified passthrough of every key beyond the known schema.
+            # Populated whenever a capability document is fetched, even if
+            # it contributed no `capabilities` — the extension surface and
+            # the capabilities list are independent.
+            cap_metadata: dict[str, Any] = {}
 
             effective_descriptor_url: str | None = None
             descriptor_source_label: Literal["cap_uri", "well_known", "none"] = "none"
@@ -749,6 +755,12 @@ async def _query_single_agent(
                         descriptor_url=effective_descriptor_url,
                     )
 
+                # Surface operator-defined cap-document fields regardless of
+                # whether the document also carried `capabilities` — trust is
+                # the caller's judgment via cap_sha256_verified (issue #174).
+                if cap_doc and cap_doc.metadata:
+                    cap_metadata = cap_doc.metadata
+
                 if cap_doc and cap_doc.capabilities:
                     capabilities = cap_doc.capabilities
                     capability_source = descriptor_source_label
@@ -835,6 +847,7 @@ async def _query_single_agent(
                 cap_uri=cap_uri,
                 cap_sha256=cap_sha256,
                 cap_sha256_verified=cap_sha256_applied,
+                cap_metadata=cap_metadata,
                 well_known_path=well_known_path,
                 bap=bap,
                 policy_uri=policy_uri,

--- a/src/dns_aid/core/models.py
+++ b/src/dns_aid/core/models.py
@@ -702,6 +702,19 @@ class AgentRecord(BaseModel):
         "or 'none'",
     )
 
+    # Operator-defined capability-document fields (issue #174)
+    cap_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Operator-defined fields of the fetched capability document — "
+        "every key beyond the known schema (capabilities, version, description, "
+        "use_cases). Opaque passthrough: NOT validated or interpreted by the "
+        "library. Integrity is judged exactly like `capabilities`: the document "
+        "came over HTTPS from the cap/well-known URI, and "
+        "`cap_sha256_verified=True` means it was covered by the record's "
+        "integrity pin. Empty when no capability document was fetched or it "
+        "defined no extra fields.",
+    )
+
     # DNS settings
     ttl: int = Field(default=3600, ge=30, le=86400, description="Time-to-live in seconds")
 

--- a/tests/unit/test_discoverer.py
+++ b/tests/unit/test_discoverer.py
@@ -20,6 +20,7 @@ from dns_aid.core.discoverer import (
     _parse_svcb_custom_params,
     _process_http_agent,
     _query_capabilities,
+    _query_single_agent,
     _reconcile_protocol,
     discover,
     discover_at_fqdn,
@@ -1975,3 +1976,117 @@ class TestCollectAgentResultsDedup:
     def test_filters_non_agent_results(self):
         a = self._rec("chat", "example.com", Protocol.MCP)
         assert len(_collect_agent_results([a, ValueError("boom"), None])) == 1
+
+
+class TestCapMetadata:
+    """Operator-defined cap-document fields surface on the record (issue #174)."""
+
+    @staticmethod
+    def _svcb_answers_with_cap() -> MagicMock:
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("mcp.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: (
+            '1 mcp.example.com. alpn="mcp" port="443" '
+            'cap="https://mcp.example.com/.well-known/agent-cap.json"'
+        )
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+        return mock_answers
+
+    @pytest.mark.asyncio
+    async def test_cap_metadata_surfaces_operator_fields(self):
+        """Non-known cap-doc keys land on AgentRecord.cap_metadata verbatim."""
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=self._svcb_answers_with_cap())
+
+        cap_doc = CapabilityDocument(
+            capabilities=["booking"],
+            version="1.0.0",
+            metadata={
+                "x-operator-tier": "gold",
+                "x-vendor": {"attestation": "https://example.com/attest"},
+            },
+        )
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                new_callable=AsyncMock,
+                return_value=cap_doc,
+            ),
+        ):
+            agent = await _query_single_agent("example.com", "booking", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.cap_metadata == {
+            "x-operator-tier": "gold",
+            "x-vendor": {"attestation": "https://example.com/attest"},
+        }
+        # Passthrough is independent of the typed fields.
+        assert agent.capabilities == ["booking"]
+
+    @pytest.mark.asyncio
+    async def test_cap_metadata_populated_even_without_capabilities(self):
+        """A cap doc with ONLY operator fields still surfaces them.
+
+        The extension surface and the capabilities list are independent —
+        an operator may publish a cap document purely to carry extension
+        metadata.
+        """
+        mock_resolver = MagicMock()
+        mock_resolver.resolve = AsyncMock(return_value=self._svcb_answers_with_cap())
+
+        cap_doc = CapabilityDocument(metadata={"x-only-extension": True})
+
+        with (
+            patch(
+                "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+                return_value=mock_resolver,
+            ),
+            patch(
+                "dns_aid.core.discoverer.fetch_cap_document",
+                new_callable=AsyncMock,
+                return_value=cap_doc,
+            ),
+        ):
+            agent = await _query_single_agent("example.com", "booking", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.cap_metadata == {"x-only-extension": True}
+        assert agent.capabilities == []
+
+    @pytest.mark.asyncio
+    async def test_cap_metadata_empty_without_cap_doc(self):
+        """No cap/well-known param → cap_metadata stays an empty dict."""
+        mock_rdata = MagicMock()
+        mock_rdata.target = dns.name.from_text("mcp.example.com.")
+        mock_rdata.priority = 1
+        mock_rdata.port = 443
+        mock_rdata.params = {}
+        mock_rdata.__str__ = lambda self: '1 mcp.example.com. alpn="mcp" port="443"'
+        mock_answers = MagicMock()
+        mock_answers.__iter__ = lambda self: iter([mock_rdata])
+        mock_resolver = MagicMock()
+
+        async def resolve(qname, rdtype):
+            if rdtype in ("SVCB", "HTTPS"):
+                return mock_answers
+            raise dns.resolver.NoAnswer()
+
+        mock_resolver.resolve = AsyncMock(side_effect=resolve)
+
+        with patch(
+            "dns_aid.core.discoverer.dns.asyncresolver.Resolver",
+            return_value=mock_resolver,
+        ):
+            agent = await _query_single_agent("example.com", "booking", Protocol.MCP)
+
+        assert agent is not None
+        assert agent.cap_metadata == {}


### PR DESCRIPTION
## Summary

Implements #174 exactly as @iracic82 specified it (all design decisions in the issue honoured — name, non-known-keys-only, always-populate, trust judged via `cap_sha256_verified`).

`CapabilityDocument` already retains every field beyond the known keys (`cap_fetcher.py` builds `.metadata` from the non-known keys), but `discover()` dropped them when constructing the `AgentRecord` — the passthrough existed at the cap-doc layer but was unreachable from the discovery result. This closes that gap with an opaque, unverified `cap_metadata: dict[str, Any]` on the record.

- Populated in `_query_single_agent` whenever a capability document is fetched — **independent of whether it also carried `capabilities`** (an operator may publish a cap doc purely to carry extension metadata).
- Explicitly NOT validated or interpreted by the library; integrity posture identical to `capabilities` (came over HTTPS from the cap/well-known URI; `cap_sha256_verified=True` means the integrity pin covered it).
- Non-goals honoured: no chain/ERC/registry or any domain-specific concept, no wire-format/SVCB/ABNF change, no new dependency, no default behaviour change. (This is also the generic extension surface that answers vendor-specific trust-param requests like #162/#161.)

Net: **+142 lines** — 13 src (models field + discoverer plumbing), 115 tests, 1 docs row.

## Test plan
- [x] New `TestCapMetadata`: operator fields surface verbatim; metadata-only cap doc still populates; absent cap doc leaves `{}`
- [x] Full unit suite: 2033 passed locally
- [x] ruff + mypy clean
- [ ] CI green

Per the issue: touches the public `AgentRecord` schema, so this should get normal CODEOWNERS review — requesting @iracic82.

Fixes #174