### PR TITLE
fix: normalize HTTP bearer auth type

### DIFF
--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -153,6 +153,13 @@ class A2AAuthentication:
                         kind = key[: -len("SecurityScheme")]
                         inner = value
                         break
+            # A2A wraps Bearer as HTTP auth, while the SDK registry uses the concrete type.
+            if (
+                isinstance(kind, str)
+                and kind.casefold() in {"http", "httpauth"}
+                and str(inner.get("scheme", "")).casefold() == "bearer"
+            ):
+                kind = "bearer"
             if kind and kind not in found:
                 found.append(kind)
             for url_field in ("tokenUrl", "openIdConnectUrl", "authorizationUrl"):

--- a/tests/unit/core/test_a2a_card_v03.py
+++ b/tests/unit/core/test_a2a_card_v03.py
@@ -146,12 +146,19 @@ class TestSecuritySchemes:
         assert auth.schemes == ["oauth2"]
         assert auth.credentials == "https://t/"
 
-    def test_the_openapi_shape(self):
+    def test_openapi_http_bearer_uses_bearer_auth_type(self):
         auth = A2AAuthentication.from_security_schemes(
             {"svc": {"type": "http", "scheme": "bearer"}}
         )
 
-        assert auth.schemes == ["http"]
+        assert auth.schemes == ["bearer"]
+
+    def test_proto_http_bearer_uses_bearer_auth_type(self):
+        auth = A2AAuthentication.from_security_schemes(
+            {"svc": {"httpAuthSecurityScheme": {"scheme": "Bearer"}}}
+        )
+
+        assert auth.schemes == ["bearer"]
 
     def test_openid_connect_url_is_taken_as_the_credential_endpoint(self):
         auth = A2AAuthentication.from_security_schemes(


### PR DESCRIPTION
## Description

Normalize A2A HTTP Bearer security schemes to the SDK's canonical `bearer` auth type.

This fixes a mismatch that prevented caller-supplied Bearer tokens from being applied. The parser previously returned `auth_type="http"` for OpenAPI security schemes and `auth_type="httpAuth"` for proto-derived security schemes, while the auth registry only recognizes `bearer`.

The fix handles both supported Agent Card shapes:

- OpenAPI style: `{"type": "http", "scheme": "bearer"}`
- Proto-derived style: `{"httpAuthSecurityScheme": {"scheme": "Bearer"}}`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have run ruff check and ruff format --check with no errors
- [x] I have run mypy src/ with no errors
- [x] I have updated documentation as needed (no documentation changes required)
- [x] My commits include a Signed-off-by line (DCO)

## Testing

- uv run --extra dev pytest tests/unit/core/test_a2a_card_v03.py tests/unit/test_auth_enrichment.py -q: 35 passed
- uv run ruff check src/ and uv run ruff format --check src/: passed
- uv run mypy src/dns_aid: passed
- uv run pytest tests/unit/ -q: 2883 passed, 2 skipped, 2 failed. The two unrelated URL safety tests fail because the local DNS environment rewrites both example.com and the reserved .invalid hostname to 198.18.0.x addresses.

## Related Issues

Relates to #256.