### PR TITLE
fix(discovery): read the endpoint from supportedInterfaces on A2A 1.0 cards

### DIFF
--- a/src/dns_aid/core/a2a_card.py
+++ b/src/dns_aid/core/a2a_card.py
@@ -366,6 +366,46 @@ class A2AAgentCard:
         """Convert skills to DNS-AID capability format (skill IDs)."""
         return self.skill_ids
 
+    def endpoint_for(self, preferred_binding: str | None = None) -> str | None:
+        """The https endpoint this card advertises, or None if it advertises none.
+
+        Precedence: the top-level ``url`` when it is https (the 0.2/0.3 shape),
+        then the interface list -- the entry whose ``protocol_binding`` equals
+        *preferred_binding* when one is asked for, otherwise the first https
+        entry.
+
+        The fallback is not a nicety for exotic cards: A2A 1.0 removed the
+        top-level ``url`` from ``AgentCard`` and made ``supportedInterfaces``
+        the required carrier of every endpoint (``a2a.proto``, ``AgentCard``
+        field 3), so a card that is conformant to the current spec reaches this
+        method with ``url == ""`` and resolves only through the list. The list
+        is ordered and "the first entry is preferred", per the same field's
+        comment, which is where the untargeted tie-break comes from.
+
+        Args:
+            preferred_binding: Transport binding to prefer, e.g. ``"JSONRPC"``.
+                Compared case-insensitively. Absent or unmatched falls back to
+                the first https entry.
+
+        Returns:
+            An https URL, or None when neither the url nor any interface
+            carries one.
+        """
+        if isinstance(self.url, str) and self.url.startswith("https://"):
+            return self.url
+
+        https_interfaces = [
+            i for i in self.interfaces if isinstance(i.url, str) and i.url.startswith("https://")
+        ]
+        if not https_interfaces:
+            return None
+        if preferred_binding:
+            wanted = preferred_binding.casefold()
+            for i in https_interfaces:
+                if (i.protocol_binding or "").casefold() == wanted:
+                    return i.url
+        return https_interfaces[0].url
+
     def to_publish_params(
         self,
         domain: str,

--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -1515,8 +1515,14 @@ async def _apply_ard_card(record: AgentRecord, http_agent: HttpIndexAgent) -> No
         except Exception:  # noqa: BLE001 — not a valid A2A card; keep catalog data
             return
         record.agent_card = card
-        if isinstance(card.url, str) and card.url.startswith("https://"):
-            _set_endpoint(card.url)
+        # endpoint_for falls back to supportedInterfaces when the card
+        # carries no top-level url, which is every A2A 1.0 card. Without
+        # the fallback the entry keeps the endpoint _http_agent_to_record
+        # derived from the catalog -- the identifier-as-locator this
+        # function exists to avoid.
+        card_endpoint = card.endpoint_for()
+        if card_endpoint:
+            _set_endpoint(card_endpoint)
         if card.skills:
             record.capabilities = card.to_capabilities()[:_MAX_ARD_CARD_CAPABILITIES]
             record.capability_source = "agent_card"
@@ -1832,6 +1838,34 @@ def _apply_agent_card(agent: AgentRecord, card: A2AAgentCard) -> None:
                 endpoint=agent.endpoint_override,
                 path=path,
             )
+
+    # A2A 1.0 carries neither the `endpoints` block (a dns-aid convention,
+    # not an A2A field) nor a top-level url: supportedInterfaces is the only
+    # place the path lives. Read it when nothing above resolved a path, and
+    # only while the interface stays on the host DNS resolved -- the SVCB
+    # record is the authority for *where* the agent is, the card only for
+    # *which path* on it. An interface pointing at another host is an
+    # internal runtime URL or a redirection the DNS owner never signed for,
+    # so it is logged and dropped rather than followed.
+    if not agent.endpoint_override:
+        card_endpoint = card.endpoint_for()
+        if card_endpoint:
+            card_host = urlparse(card_endpoint).hostname
+            if card_host == agent.target_host:
+                agent.endpoint_override = card_endpoint
+                agent.endpoint_source = "dns_svcb_enriched"
+                logger.debug(
+                    "Enriched agent endpoint from agent card interfaces",
+                    agent=agent.name,
+                    endpoint=card_endpoint,
+                )
+            else:
+                logger.debug(
+                    "Agent card interface is off-host; keeping the DNS endpoint",
+                    agent=agent.name,
+                    card_host=card_host,
+                    dns_host=agent.target_host,
+                )
 
     # Extract auth metadata from card (A2A format)
     # Only populate if not already set (DNS-AID native AuthSpec takes precedence)

--- a/src/dns_aid/core/invoke.py
+++ b/src/dns_aid/core/invoke.py
@@ -510,7 +510,12 @@ async def resolve_a2a_endpoint(
                 # that isn't publicly reachable via the same proxy/CDN.
                 card = await fetch_agent_card(discovered_endpoint, timeout=5.0)
                 if card:
-                    card_host = urlparse(card.url).hostname if card.url else None
+                    # endpoint_for falls back to supportedInterfaces when the
+                    # card has no top-level url (every A2A 1.0 card), and
+                    # prefers the JSONRPC binding because _invoke_raw_a2a
+                    # speaks JSON-RPC over HTTP.
+                    card_url = card.endpoint_for("JSONRPC")
+                    card_host = urlparse(card_url).hostname if card_url else None
                     dns_host = urlparse(discovered_endpoint).hostname
                     use_card_url = card_host == dns_host if card_host else False
                     if not use_card_url and card_host:
@@ -521,7 +526,7 @@ async def resolve_a2a_endpoint(
                         )
 
                     return ResolvedAgent(
-                        endpoint=card.url if use_card_url else discovered_endpoint,
+                        endpoint=card_url if use_card_url else discovered_endpoint,
                         agent_name=card.name,
                         agent_description=card.description,
                         skills=[s.name for s in card.skills],
@@ -547,17 +552,18 @@ async def resolve_a2a_endpoint(
         )
 
     # Path 2: Fetch agent card from the given endpoint for metadata.
-    # Use card.url only if it matches the host we were given.
+    # Use the card's own endpoint only if it matches the host we were given.
     normalized = normalize_endpoint(endpoint)
     try:
         card = await fetch_agent_card(normalized, timeout=5.0)
         if card:
-            card_host = urlparse(card.url).hostname if card.url else None
+            card_url = card.endpoint_for("JSONRPC")
+            card_host = urlparse(card_url).hostname if card_url else None
             given_host = urlparse(normalized).hostname
             use_card_url = card_host == given_host if card_host else False
 
             return ResolvedAgent(
-                endpoint=card.url if use_card_url else normalized,
+                endpoint=card_url if use_card_url else normalized,
                 agent_name=card.name,
                 agent_description=card.description,
                 skills=[s.name for s in card.skills],

--- a/tests/unit/core/test_a2a_card_v10_endpoint.py
+++ b/tests/unit/core/test_a2a_card_v10_endpoint.py
@@ -1,0 +1,148 @@
+"""A2A 1.0 cards must contribute their endpoint.
+
+1.0 removed the top-level ``url`` from ``AgentCard`` and made
+``supportedInterfaces`` the required carrier of every endpoint
+(``a2a.proto``, ``AgentCard`` field 3). The card object has parsed that list
+since 0.3 support landed, but nothing read it back, so a conformant 1.0 card
+resolved to whatever the *caller* already had -- the catalog domain on the ARD
+path, the bare SVCB origin on the DNS path. These tests pin the read.
+"""
+
+from __future__ import annotations
+
+from dns_aid.core.a2a_card import A2AAgentCard, A2AInterface, A2ASkill
+from dns_aid.core.discoverer import _apply_agent_card
+from dns_aid.core.models import AgentRecord, Protocol
+
+CARD_1_0 = {
+    "name": "Example Agent",
+    "description": "Minimal conformant A2A 1.0 card.",
+    "version": "1.0.0",
+    "supportedInterfaces": [
+        {
+            "url": "https://agent.example.com/a2a",
+            "protocolBinding": "JSONRPC",
+            "protocolVersion": "1.0",
+        }
+    ],
+    "capabilities": {"streaming": False},
+    "defaultInputModes": ["application/json"],
+    "defaultOutputModes": ["application/json"],
+    "skills": [{"id": "example", "name": "Example", "description": "x", "tags": ["example"]}],
+}
+
+
+def _record(target_host: str = "agent.example.com") -> AgentRecord:
+    return AgentRecord(
+        name="agent",
+        domain="example.com",
+        protocol=Protocol.A2A,
+        target_host=target_host,
+        port=443,
+    )
+
+
+class TestEndpointFor:
+    def test_conformant_1_0_card_resolves_through_the_interface_list(self):
+        """The shape the current spec mandates: no url, one interface."""
+        card = A2AAgentCard.from_dict(CARD_1_0)
+
+        assert card.url == "", "1.0 cards carry no top-level url"
+        assert card.endpoint_for() == "https://agent.example.com/a2a"
+
+    def test_top_level_url_wins_when_present(self):
+        """0.2/0.3 cards keep resolving exactly as before."""
+        card = A2AAgentCard(
+            name="a",
+            url="https://agent.example.com/legacy",
+            interfaces=[A2AInterface(url="https://agent.example.com/a2a")],
+        )
+
+        assert card.endpoint_for() == "https://agent.example.com/legacy"
+
+    def test_preferred_binding_selects_its_interface(self):
+        card = A2AAgentCard(
+            name="a",
+            url="",
+            interfaces=[
+                A2AInterface(url="https://agent.example.com/grpc", protocol_binding="GRPC"),
+                A2AInterface(url="https://agent.example.com/a2a", protocol_binding="JSONRPC"),
+            ],
+        )
+
+        assert card.endpoint_for("JSONRPC") == "https://agent.example.com/a2a"
+        assert card.endpoint_for("jsonrpc") == "https://agent.example.com/a2a"
+
+    def test_unmatched_binding_falls_back_to_the_first_entry(self):
+        """`a2a.proto`: the list is ordered and the first entry is preferred."""
+        card = A2AAgentCard(
+            name="a",
+            url="",
+            interfaces=[
+                A2AInterface(url="https://agent.example.com/grpc", protocol_binding="GRPC"),
+                A2AInterface(url="https://agent.example.com/rest", protocol_binding="HTTP+JSON"),
+            ],
+        )
+
+        assert card.endpoint_for("JSONRPC") == "https://agent.example.com/grpc"
+
+    def test_no_https_anywhere_resolves_to_none(self):
+        card = A2AAgentCard(
+            name="a",
+            url="http://agent.example.com",
+            interfaces=[A2AInterface(url="http://agent.example.com/a2a")],
+        )
+
+        assert card.endpoint_for() is None
+
+
+class TestApplyAgentCardUsesInterfaces:
+    def test_interface_on_the_dns_host_becomes_the_endpoint(self):
+        agent = _record()
+        card = A2AAgentCard.from_dict(CARD_1_0)
+
+        _apply_agent_card(agent, card)
+
+        assert agent.endpoint_override == "https://agent.example.com/a2a"
+        assert agent.endpoint_source == "dns_svcb_enriched"
+
+    def test_off_host_interface_is_not_followed(self):
+        """DNS says *where*; the card only says *which path*.
+
+        An interface on another host is an internal runtime URL or a
+        redirection the DNS owner never signed for.
+        """
+        agent = _record()
+        card = A2AAgentCard.from_dict(
+            {**CARD_1_0, "supportedInterfaces": [{"url": "https://internal.aws.example/a2a"}]}
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.endpoint_override is None
+        assert agent.endpoint_url == "https://agent.example.com:443"
+
+    def test_dns_aid_endpoints_block_still_wins(self):
+        """No regression: the `endpoints` convention keeps precedence."""
+        agent = _record()
+        card = A2AAgentCard.from_dict(CARD_1_0)
+        card.metadata["endpoints"] = {"a2a": "/from-metadata"}
+
+        _apply_agent_card(agent, card)
+
+        assert agent.endpoint_override == "https://agent.example.com:443/from-metadata"
+
+    def test_skills_still_become_capabilities(self):
+        """The endpoint read must not disturb the rest of enrichment."""
+        agent = _record()
+        card = A2AAgentCard(
+            name="a",
+            url="",
+            interfaces=[A2AInterface(url="https://agent.example.com/a2a")],
+            skills=[A2ASkill(id="payments", name="Payments", description="", tags=[])],
+        )
+
+        _apply_agent_card(agent, card)
+
+        assert agent.capabilities == ["payments"]
+        assert agent.capability_source == "agent_card"

--- a/tests/unit/core/test_invoke.py
+++ b/tests/unit/core/test_invoke.py
@@ -73,13 +73,27 @@ def _mock_agent_client(mock_client_cls, *, invoke_return=None, invoke_side_effec
     return mock_client
 
 
-def _card(url, name="Chat Agent", description="A chat agent", skill_names=("chatting",)):
-    """Duck-typed A2A agent card."""
-    return SimpleNamespace(
+def _card(
+    url,
+    name="Chat Agent",
+    description="A chat agent",
+    skill_names=("chatting",),
+    interfaces=(),
+):
+    """A real A2A agent card.
+
+    Was a SimpleNamespace duck type; resolution now goes through the card's
+    own ``endpoint_for``, so the double has to be the real object rather than
+    a bag of the attributes the resolver happened to read.
+    """
+    from dns_aid.core.a2a_card import A2AAgentCard, A2AInterface, A2ASkill
+
+    return A2AAgentCard(
         url=url,
         name=name,
         description=description,
-        skills=[SimpleNamespace(name=s) for s in skill_names],
+        skills=[A2ASkill(id=s, name=s) for s in skill_names],
+        interfaces=[A2AInterface(url=u, protocol_binding=b) for u, b in interfaces],
     )
 
 
@@ -792,6 +806,26 @@ class TestResolveA2AEndpoint:
     @pytest.mark.asyncio
     async def test_agent_card_without_url_keeps_endpoint(self):
         card = _card("")
+
+        with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com"
+
+    @pytest.mark.asyncio
+    async def test_a2a_1_0_card_resolves_through_supported_interfaces(self):
+        """1.0 removed the top-level url; the interface list carries it."""
+        card = _card("", interfaces=[("https://agent.example.com/a2a", "JSONRPC")])
+
+        with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
+            resolved = await resolve_a2a_endpoint("agent.example.com")
+
+        assert resolved.endpoint == "https://agent.example.com/a2a"
+        assert resolved.resolved_via == "agent_card"
+
+    @pytest.mark.asyncio
+    async def test_a2a_1_0_card_interface_off_host_is_not_followed(self):
+        card = _card("", interfaces=[("https://elsewhere.example.net/a2a", "JSONRPC")])
 
         with patch("dns_aid.core.a2a_card.fetch_agent_card", AsyncMock(return_value=card)):
             resolved = await resolve_a2a_endpoint("agent.example.com")


### PR DESCRIPTION
Fixes #258.

**BLUF.** `from_dict` has parsed `supportedInterfaces` into `card.interfaces` since 0.3 support landed, but no consumer read it back — endpoint derivation went through `card.url` alone. A2A 1.0 removed the top-level `url`, so a conformant 1.0 card parses with `url == ""` and each consumer falls through to a value that never came from the card.

**What.** `A2AAgentCard.endpoint_for(preferred_binding=None)`: the top-level https `url` first, so 0.2/0.3 cards resolve exactly as before, then the interface list — the entry whose `protocol_binding` matches, else the first https entry, per the proto's *"Ordered list of supported interfaces. The first entry is preferred."* Returns `None` when neither carries https.

Wired into the three consumers:

- `_apply_ard_card` — without it the entry keeps the endpoint `_http_agent_to_record` derived from the catalog, which is the identifier-as-locator the function's own docstring rejects (ARD §4.2.1).
- `_apply_agent_card` — after the `endpoints` metadata block, so the dns-aid convention keeps precedence. The interface is used **only** when its host equals the host DNS resolved: the SVCB record is the authority for *where* the agent is, the card only for *which path* on it. An off-host interface is logged and dropped.
- `resolve_a2a_endpoint`, both branches — preferring `JSONRPC`, since `_invoke_raw_a2a` speaks JSON-RPC over HTTP. The existing same-host guard is unchanged and now applies to whichever URL the card yields.

**Tests.** New `tests/unit/core/test_a2a_card_v10_endpoint.py`, 9 cases: a conformant 1.0 card resolves through the interface list; the top-level url still wins when present; a requested binding selects its interface (case-insensitively); an unmatched binding falls back to the first entry; nothing-https resolves to `None`; `_apply_agent_card` takes an on-host interface, refuses an off-host one, still lets the `endpoints` block win, and still wires skills to capabilities. Two more in `test_invoke.py` for the 1.0 card through `resolve_a2a_endpoint`, on-host and off-host.

`test_invoke`'s card double was a `SimpleNamespace` carrying the attributes the resolver happened to read. Resolution now goes through the card's own method, so `_card()` builds a real `A2AAgentCard` — a stronger double, and the four tests that exercised it are unchanged otherwise.

**Gate.** `uv run pytest tests/unit/` — 2895 passed, 2 skipped. `ruff check` and `ruff format --check` clean.

**Yours to change.** The precedence when several interfaces qualify is a design call. This implements the reading the proto's own ordering comment suggests; say the word and I will change it — including whether the DNS path should follow an off-host interface at all, which I have deliberately made it refuse.
