### PR TITLE
docs(discovery): correct a comment claiming DNSSEC suppresses JWS verification

### DIFF
--- a/src/dns_aid/core/discoverer.py
+++ b/src/dns_aid/core/discoverer.py
@@ -803,9 +803,10 @@ async def _query_single_agent(
             enroll_uri = custom_params.get("enroll-uri")
             # The JWS record signature (`sig`, key65405). Parsing is
             # unconditional and independent of DNSSEC: the value is carried on
-            # the record whether or not it will later be verified. Whether JWS
-            # verification actually runs is decided in _verify_agent_signatures,
-            # which skips agents whose owner name validated under DNSSEC.
+            # the record whether or not it will later be verified. Verification
+            # itself runs for every agent carrying a sig -- see
+            # _verify_agent_signatures for why a DNSSEC-validated record does
+            # not suppress it.
             # Every name in DNS_AID_KEY_MAP must be extracted here; the
             # completeness test in tests/unit/core/test_svcb_param_coverage.py
             # fails if a key is added to the map without being wired up.


### PR DESCRIPTION
**BLUF.** One comment, no behaviour change. The comment above the `sig` extraction in `discoverer.py` says JWS verification "skips agents whose owner name validated under DNSSEC". Three other places in the codebase say the opposite, and they are the ones that are right.

`_verify_agent_signatures`, the function the comment points at, in its own docstring:

> There is deliberately no way to suppress this. A DNSSEC-validated record used to skip JWS on the grounds that the DNS chain was the stronger guarantee — but that signal is the AD flag with no chain validation, and an attacker who can forge answers for an unsigned zone (the adversary the JWS fallback exists to stop) sets it at will. The parameter that carried the skip is gone rather than merely unused, so a future caller cannot reopen it.

`jwks.py`, at `SignatureStatus.SKIPPED_DNSSEC`: *"RETAINED FOR WIRE COMPATIBILITY, NO LONGER PRODUCED."* And the MCP server's tool documentation: *"`skipped_dnssec` = no longer produced by this tool."*

**Why bother with a comment.** It misleads in an expensive direction. A publisher who reads it concludes that signing a record in a DNSSEC-signed zone buys nothing, and skips publishing `sig` on the strength of exactly the weaker guarantee the next paragraph dismantles. That is the reading I arrived at before finding the docstring that contradicts it.

No issue filed — it is one line, and the fix is the whole argument.
